### PR TITLE
ENG-8807 XL Op upgrade doesn't work correctly for OpenShift if to point to config in ~/.kube/config

### DIFF
--- a/pkg/blueprint/blueprint_expressions.go
+++ b/pkg/blueprint/blueprint_expressions.go
@@ -194,7 +194,7 @@ func getExpressionFunctions(params map[string]interface{}, overrideFnMethods map
 			// - 1: Context name [optional]
 			attr := fmt.Sprintf("%v", args[0])
 
-			if !funk.Contains([]string{"ClusterServer", "ClusterInsecureSkipTLSVerify", "ContextCluster", "ContextNamespace", "ContextUser", "UserClientCertificateData", "UserClientKeyData", "IsAvailable", "IsConfigAvailable"}, attr) {
+			if !funk.Contains([]string{"ClusterServer", "ClusterInsecureSkipTLSVerify", "ContextCluster", "ContextNamespace", "ContextUser", "UserClientCertificateData", "UserClientKeyData", "IsAvailable", "IsConfigAvailable", "UserToken", "IsUserTokenAvailable"}, attr) {
 				return nil, fmt.Errorf("attribute '%s' is not valid for expression function 'k8sConfig'", attr)
 			}
 
@@ -226,6 +226,11 @@ func getExpressionFunctions(params map[string]interface{}, overrideFnMethods map
 			if attr == "IsAvailable" {
 				return k8sConfig.Cluster.Server != "", nil
 			}
+
+			if attr == "IsUserTokenAvailable" {
+			    return k8sConfig.User.Token != "", nil
+            }
+
 			return k8sConfig.GetConfigField(attr, true), nil
 		},
 

--- a/pkg/cloud/k8s/k8s_helper.go
+++ b/pkg/cloud/k8s/k8s_helper.go
@@ -62,6 +62,7 @@ type K8sUserItem struct {
 	ClientKeyData         string `yaml:"client-key-data,omitempty"`
 	ClientCertificate     string `yaml:"client-certificate,omitempty"`
 	ClientKey             string `yaml:"client-key,omitempty"`
+	Token                 string `yaml:"token,omitempty"`
 }
 
 type K8SFnResult struct {


### PR DESCRIPTION
https://digitalai.atlassian.net/browse/ENG-8807

In case user decided to use his local .kube/config as the source of data for connecting to his cluster, and that file had user token inside it, the xl-infra blueprint wasn't able to read the token. Only manual entry was possible. Changes in this PR make automatic reading of the token possible (along with [changes in xl-op-blueprints](https://github.com/xebialabs/xl-op-blueprints/pull/20))

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code can be build by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] If a new library is added, make sure the license is checked and embedded in the `xl license` command. (See [README](https://github.com/xebialabs/xl-blueprint#bundling-license-information))

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Functionality is manually tested with dockerised instances of our products
- [ ] Automated unit tests added and are green
- [ ] Automated integration tests added where needed and are green
