### PR TITLE
ENG-8807 XL Op upgrade doesn't work correctly for OpenShift if to poi…

### DIFF
--- a/pkg/blueprint/blueprint_doc.go
+++ b/pkg/blueprint/blueprint_doc.go
@@ -382,9 +382,10 @@ func (variable *Variable) GetUserInput(defaultVal interface{}, parameters map[st
 			answer = defaultValStr
 		}
 	case TypeEditor, TypeSecretEditor:
+		questionMsg := prepareQuestionText(variable.Prompt.Value, fmt.Sprintf("What is the value of %s?", variable.Name.Value))
 		err = survey.AskOne(
 			&survey.Editor{
-				Message:       prepareQuestionText(variable.Prompt.Value, fmt.Sprintf("What is the value of %s?", variable.Name.Value)),
+				Message:       questionMsg,
 				Default:       defaultValStr,
 				HideDefault:   true,
 				AppendDefault: true,
@@ -394,6 +395,11 @@ func (variable *Variable) GetUserInput(defaultVal interface{}, parameters map[st
 			validatePrompt(variable.Name.Value, validateExpr, false, parameters, overrideFns),
 			surveyOpts...,
 		)
+		// if user bypassed question, replace with default value
+		if answer == "" {
+			util.Verbose("[input] Got empty response for secret field '%s', replacing with default value: %s\n", variable.Name.Value, defaultVal)
+			answer = defaultValStr
+		}
 	case TypeFile, TypeSecretFile:
 		var filePath string
 		err = survey.AskOne(

--- a/pkg/blueprint/blueprint_expressions.go
+++ b/pkg/blueprint/blueprint_expressions.go
@@ -228,8 +228,8 @@ func getExpressionFunctions(params map[string]interface{}, overrideFnMethods map
 			}
 
 			if attr == "IsUserTokenAvailable" {
-			    return k8sConfig.User.Token != "", nil
-            }
+				return k8sConfig.User.Token != "", nil
+			}
 
 			return k8sConfig.GetConfigField(attr, true), nil
 		},


### PR DESCRIPTION
…nt to config in ~/.kube/config

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code can be build by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] If a new library is added, make sure the license is checked and embedded in the `xl license` command. (See [README](https://github.com/xebialabs/xl-blueprint#bundling-license-information))

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Functionality is manually tested with dockerised instances of our products
- [ ] Automated unit tests added and are green
- [ ] Automated integration tests added where needed and are green
