### PR TITLE
D-32374 Fix questions asked after remote runner installation

### DIFF
--- a/pkg/blueprint/blueprint_doc.go
+++ b/pkg/blueprint/blueprint_doc.go
@@ -538,7 +538,7 @@ func (blueprintDoc *BlueprintConfig) prepareTemplateData(params BlueprintParams,
 				variable.Default.Bool = boolVal
 			}
 			// remove the variable from answers if this is coming from UP command so that question will be asked in the upgrade flow
-			if params.FromUpCommand {
+			if params.FromUpCommand && len(params.OverrideDefaults) == 0 {
 				delete(answerMap, variable.Name.Value)
 			}
 		} else {


### PR DESCRIPTION
Override yaml fields are wrongly removed from answers causing user prompt again during remote runner

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code can be build by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] If a new library is added, make sure the license is checked and embedded in the `xl license` command. (See [README](https://github.com/xebialabs/xl-blueprint#bundling-license-information))

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Functionality is manually tested with dockerised instances of our products
- [ ] Automated unit tests added and are green
- [ ] Automated integration tests added where needed and are green
