### PR TITLE
D-33671 Proper handling of option answer string during validation

### DIFF
--- a/pkg/blueprint/blueprint_doc.go
+++ b/pkg/blueprint/blueprint_doc.go
@@ -719,7 +719,7 @@ func validatePrompt(varName string, validateExpr string, allowEmpty bool, parame
 		case string:
 			value = strings.TrimSpace(valType)
 		default:
-			value = val
+			value = fmt.Sprint(val)
 		}
 		// if empty value is not allowed, check for any value
 		if !allowEmpty {

--- a/pkg/blueprint/blueprint_doc.go
+++ b/pkg/blueprint/blueprint_doc.go
@@ -721,8 +721,12 @@ func validatePrompt(varName string, validateExpr string, allowEmpty bool, parame
 			value = strings.TrimSpace(valType)
 		case core.OptionAnswer:
 			value = val.(core.OptionAnswer).Value
+			beforeLabel, _, found := strings.Cut(value.(string), "[")
+			if found {
+				value = strings.TrimSpace(beforeLabel)
+			}
 		default:
-			value = fmt.Sprint(val)
+			value = val
 		}
 		// if empty value is not allowed, check for any value
 		if !allowEmpty {

--- a/pkg/blueprint/blueprint_doc.go
+++ b/pkg/blueprint/blueprint_doc.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/thoas/go-funk"
 
 	"github.com/xebialabs/blueprint-cli/pkg/cloud/aws"
@@ -718,6 +719,8 @@ func validatePrompt(varName string, validateExpr string, allowEmpty bool, parame
 		switch valType := val.(type) {
 		case string:
 			value = strings.TrimSpace(valType)
+		case core.OptionAnswer:
+			value = val.(core.OptionAnswer).Value
 		default:
 			value = fmt.Sprint(val)
 		}


### PR DESCRIPTION
Fix to validate on the option value. As per expected usage in blueprints yaml.

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code can be build by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] If a new library is added, make sure the license is checked and embedded in the `xl license` command. (See [README](https://github.com/xebialabs/xl-blueprint#bundling-license-information))

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Functionality is manually tested with dockerised instances of our products
- [ ] Automated unit tests added and are green
- [ ] Automated integration tests added where needed and are green
