### PR TITLE
S-121091 [24.3] Improve error handling selection prompt when options are empty

### DIFF
--- a/pkg/blueprint/blueprint_doc_test.go
+++ b/pkg/blueprint/blueprint_doc_test.go
@@ -1458,7 +1458,7 @@ func Test_getDefaultTextWithLabel(t *testing.T) {
 					InvertBool: false,
 				},
 				{
-					Label:      "someFun()",
+					Label:      "",
 					Value:      "someFun()",
 					Bool:       false,
 					Tag:        "!expr",
@@ -1477,21 +1477,39 @@ func Test_getDefaultTextWithLabel(t *testing.T) {
 			},
 			[]VarField{
 				{
-					Label:      "Yoyo",
+					Label:      "",
 					Value:      "yoyo",
 					Bool:       false,
-					Tag:        "!expr",
+					Tag:        "",
 					InvertBool: false,
 				},
 				{
-					Label:      "Hiya",
+					Label:      "",
 					Value:      "hiya",
+					Bool:       false,
+					Tag:        "",
+					InvertBool: false,
+				},
+				{
+					Label:      "",
+					Value:      "someFun()",
 					Bool:       false,
 					Tag:        "!expr",
 					InvertBool: false,
 				},
+			},
+			"hiya",
+		},
+		{
+			"should return default value without label(options evaluated from func & default is one of them)",
+			"hiya",
+			[]string{
+				"yoyo",
+				"hiya",
+			},
+			[]VarField{
 				{
-					Label:      "someFun()",
+					Label:      "",
 					Value:      "someFun()",
 					Bool:       false,
 					Tag:        "!expr",
@@ -1532,6 +1550,70 @@ func Test_getDefaultTextWithLabel(t *testing.T) {
 				},
 			},
 			"yaya",
+		},
+		{
+			"should return the first option as default if no default value given",
+			"",
+			[]string{
+				"yoyo [Yoyo]",
+				"hiya [Hiya]",
+				"someResult1",
+				"someResult2",
+			},
+			[]VarField{
+				{
+					Label:      "Yoyo",
+					Value:      "yoyo",
+					Bool:       false,
+					Tag:        "",
+					InvertBool: false,
+				},
+				{
+					Label:      "Hiya",
+					Value:      "hiya",
+					Bool:       false,
+					Tag:        "",
+					InvertBool: false,
+				},
+				{
+					Label:      "someFun()",
+					Value:      "someFun()",
+					Bool:       false,
+					Tag:        "!expr",
+					InvertBool: false,
+				},
+			},
+			"yoyo [Yoyo]",
+		},
+		{
+			"should return empty default value if no default value given and no options present",
+			"",
+			[]string{},
+			[]VarField{
+				{
+					Label:      "",
+					Value:      "someFun()",
+					Bool:       false,
+					Tag:        "!expr",
+					InvertBool: false,
+				},
+			},
+			"",
+		},
+		{
+			"should return default value if no options present",
+			"hiya",
+			[]string{},
+			[]VarField{
+				{
+					Label:      "",
+					Value:      "someFun()",
+					Bool:       false,
+					Tag:        "!expr",
+					InvertBool: false,
+				},
+			},
+			"hiya",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code can be build by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] If a new library is added, make sure the license is checked and embedded in the `xl license` command. (See [README](https://github.com/xebialabs/xl-blueprint#bundling-license-information))

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Functionality is manually tested with dockerised instances of our products
- [ ] Automated unit tests added and are green
- [ ] Automated integration tests added where needed and are green
