### PR TITLE
S-135233 Introduced success logging when waiting for resource

### DIFF
--- a/pkg/cloud/k8s/k8s_resource.go
+++ b/pkg/cloud/k8s/k8s_resource.go
@@ -400,8 +400,9 @@ func (r Resource) WaitForResourceComplex(timeoutMinutes uint, condition string) 
 				fmt.Sprintf("--timeout=%ds", timeoutMinutes*60),
 				"-n", r.Namespace))
 			if err == nil {
+				r.spin.Stop()
 				elapsed := time.Since(start)
-				util.Info("Resource %s reached condition %s (elapsed: %v)\n", resource, condition, elapsed)
+				util.Info("%s reached condition %s in %v\n", resource, condition, elapsed)
 				return nil
 			} else {
 				util.Verbose("Failed waiting for %s to be %s: %s \n%s\n", resource, condition, err.Error(), log)
@@ -434,8 +435,9 @@ func (r Resource) WaitForResource(timeoutMinutes uint, condition string) error {
 				fmt.Sprintf("--timeout=%ds", timeoutMinutes*60),
 				"-n", r.Namespace))
 			if err == nil {
+				r.spin.Stop()
 				elapsed := time.Since(start)
-				util.Info("Resource %s reached condition %s (elapsed: %v)\n", resource, condition, elapsed)
+				util.Info("%s reached condition %s in %v\n", resource, condition, elapsed)
 				return nil
 			} else {
 				util.Verbose("Failed waiting for %s to be %s: %s \n%s\n", resource, condition, err.Error(), log)

--- a/pkg/cloud/k8s/k8s_resource.go
+++ b/pkg/cloud/k8s/k8s_resource.go
@@ -400,6 +400,8 @@ func (r Resource) WaitForResourceComplex(timeoutMinutes uint, condition string) 
 				fmt.Sprintf("--timeout=%ds", timeoutMinutes*60),
 				"-n", r.Namespace))
 			if err == nil {
+				elapsed := time.Since(start)
+				util.Info("Resource %s reached condition %s (elapsed: %v)\n", resource, condition, elapsed)
 				return nil
 			} else {
 				util.Verbose("Failed waiting for %s to be %s: %s \n%s\n", resource, condition, err.Error(), log)
@@ -432,6 +434,8 @@ func (r Resource) WaitForResource(timeoutMinutes uint, condition string) error {
 				fmt.Sprintf("--timeout=%ds", timeoutMinutes*60),
 				"-n", r.Namespace))
 			if err == nil {
+				elapsed := time.Since(start)
+				util.Info("Resource %s reached condition %s (elapsed: %v)\n", resource, condition, elapsed)
 				return nil
 			} else {
 				util.Verbose("Failed waiting for %s to be %s: %s \n%s\n", resource, condition, err.Error(), log)


### PR DESCRIPTION
 Since success state is not explicitly logged after waiting.

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code can be build by Jenkins
 - [ ] Code is reviewed and tested by someone else in the team
 - [ ] If a new library is added, make sure the license is checked and embedded in the `xl license` command. (See [README](https://github.com/xebialabs/xl-blueprint#bundling-license-information))

**Testing**
- [ ] Works on Linux, Windows and Mac
- [ ] Functionality is manually tested with dockerised instances of our products
- [ ] Automated unit tests added and are green
- [ ] Automated integration tests added where needed and are green
